### PR TITLE
Add python 3

### DIFF
--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -71,7 +71,11 @@ LANG_JAVA = "java"
 # Format seems standard as cpython-<MAJOR><MINOR> for cpython.
 # Fetch python3 minor version to make compile PYTHON3_COMPILE_NAME correct for local setup
 # python3 -V returns "Python M.m.p\n"
-PYTHON3_COMPILE_NAME = "cpython-3" + subprocess.check_output(["python3", "-V"]).split()[1].split('.')[1]
+try:
+    PYTHON3_COMPILE_NAME = "cpython-3" + subprocess.check_output(["python3", "-V"]).split()[1].split('.')[1]
+except (subprocess.CalledProcessError, OSError):
+    # Python 3 not installed, no point in handling here as it will fail anyway when trying to submit
+    PYTHON3_COMPILE_NAME = None
 
 LANGUAGE_NAMES = {
     LANG_C: "C",

--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -65,6 +65,9 @@ LANG_PYTHON3 = "py3"
 LANG_PHP = "php"
 LANG_JAVA = "java"
 
+# Python 3 :(
+PYTHON3_COMPILE_NAME = "cpython-%d%d" % (3, 4)
+
 LANGUAGE_NAMES = {
     LANG_C: "C",
     LANG_CPP: "C++",

--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -35,7 +35,7 @@ import cms.log
 
 __all__ = [
     "LANG_C", "LANG_CPP", "LANG_PASCAL", "LANG_PYTHON2", "LANG_PYTHON3", "LANG_PHP", "LANG_CS"
-    "LANGUAGE_NAMES", "LANGUAGES", "DEFAULT_LANGUAGES",
+    "LANGUAGE_NAMES", "LANGUAGES", "DEFAULT_LANGUAGES", "PYTHON3_COMPILE_NAME",
     "SOURCE_EXT_TO_LANGUAGE_MAP",
     "LANGUAGE_TO_SOURCE_EXT_MAP", "LANGUAGE_TO_HEADER_EXT_MAP",
     "LANGUAGE_TO_OBJ_EXT_MAP", "LANGUAGE_TO_MAX_PROCCESSORS",
@@ -65,7 +65,9 @@ LANG_PYTHON3 = "py3"
 LANG_PHP = "php"
 LANG_JAVA = "java"
 
-# Python 3 :(
+# Python 3 py_compile outputs to __pycache__/filename.<PYTHON3_COMPILE_NAME>.pyc
+# Using a '*' in this place does not appear to work correctly.
+# Format seems standard as cpython-<MAJOR><MINOR> for cpython.
 PYTHON3_COMPILE_NAME = "cpython-%d%d" % (3, 4)
 
 LANGUAGE_NAMES = {

--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -34,7 +34,7 @@ import cms.log
 # Define what this package will provide.
 
 __all__ = [
-    "LANG_C", "LANG_CPP", "LANG_PASCAL", "LANG_PYTHON", "LANG_PHP", "LANG_CS"
+    "LANG_C", "LANG_CPP", "LANG_PASCAL", "LANG_PYTHON2", "LANG_PYTHON3", "LANG_PHP", "LANG_CS"
     "LANGUAGE_NAMES", "LANGUAGES", "DEFAULT_LANGUAGES",
     "SOURCE_EXT_TO_LANGUAGE_MAP",
     "LANGUAGE_TO_SOURCE_EXT_MAP", "LANGUAGE_TO_HEADER_EXT_MAP",
@@ -60,7 +60,8 @@ LANG_C = "c"
 LANG_CPP = "cpp"
 LANG_CS = "cs"
 LANG_PASCAL = "pas"
-LANG_PYTHON = "py"
+LANG_PYTHON2 = "py2"
+LANG_PYTHON3 = "py3"
 LANG_PHP = "php"
 LANG_JAVA = "java"
 
@@ -69,12 +70,13 @@ LANGUAGE_NAMES = {
     LANG_CPP: "C++",
     LANG_CS: "C#",
     LANG_PASCAL: "Pascal",
-    LANG_PYTHON: "Python",
+    LANG_PYTHON2: "Python 2",
+    LANG_PYTHON3: "Python 3",
     LANG_PHP: "PHP",
     LANG_JAVA: "Java",
 }
 
-LANGUAGES = [LANG_C, LANG_CPP, LANG_CS, LANG_PASCAL, LANG_PYTHON, LANG_PHP, LANG_JAVA]
+LANGUAGES = [LANG_C, LANG_CPP, LANG_CS, LANG_PASCAL, LANG_PYTHON2, LANG_PYTHON3, LANG_PHP, LANG_JAVA]
 DEFAULT_LANGUAGES = [LANG_C, LANG_CPP, LANG_PASCAL]
 
 # Language specific max_processor requirements
@@ -95,7 +97,8 @@ SOURCE_EXT_TO_LANGUAGE_MAP = {
     ".c++": LANG_CPP,
     ".cs": LANG_CS,
     ".pas": LANG_PASCAL,
-    ".py": LANG_PYTHON,
+    ".py2": LANG_PYTHON2,
+    ".py3": LANG_PYTHON3,
     ".php": LANG_PHP,
     ".java": LANG_JAVA,
 }
@@ -106,7 +109,8 @@ LANGUAGE_TO_SOURCE_EXT_MAP = {
     LANG_CPP: ".cpp",
     LANG_CS: ".cs",
     LANG_PASCAL: ".pas",
-    LANG_PYTHON: ".py",
+    LANG_PYTHON2: ".py2",
+    LANG_PYTHON3: ".py3",
     LANG_PHP: ".php",
     LANG_JAVA: ".java",
 }

--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -30,6 +30,7 @@ from __future__ import unicode_literals
 # handlers will be added by services by calling initialize_logging.
 import cms.log
 
+import subprocess
 
 # Define what this package will provide.
 
@@ -68,7 +69,9 @@ LANG_JAVA = "java"
 # Python 3 py_compile outputs to __pycache__/filename.<PYTHON3_COMPILE_NAME>.pyc
 # Using a '*' in this place does not appear to work correctly.
 # Format seems standard as cpython-<MAJOR><MINOR> for cpython.
-PYTHON3_COMPILE_NAME = "cpython-%d%d" % (3, 4)
+# Fetch python3 minor version to make compile PYTHON3_COMPILE_NAME correct for local setup
+# python3 -V returns "Python M.m.p\n"
+PYTHON3_COMPILE_NAME = "cpython-3" + subprocess.check_output(["python3", "-V"]).split()[1].split('.')[1]
 
 LANGUAGE_NAMES = {
     LANG_C: "C",

--- a/cms/grading/Sandbox.py
+++ b/cms/grading/Sandbox.py
@@ -1215,6 +1215,7 @@ class IsolateSandbox(SandboxBase):
         args = [self.box_exec] + self.build_box_options() + ["--"] + command
         logger.debug("Executing program in sandbox with command: `%s'.",
                      pretty_print_cmdline(args))
+        print("Isolate:", " ".join(args))
         # Temporarily allow writing new files.
         prev_permissions = stat.S_IMODE(os.stat(self.path).st_mode)
         os.chmod(self.path, 0777)

--- a/cms/grading/Sandbox.py
+++ b/cms/grading/Sandbox.py
@@ -1215,7 +1215,6 @@ class IsolateSandbox(SandboxBase):
         args = [self.box_exec] + self.build_box_options() + ["--"] + command
         logger.debug("Executing program in sandbox with command: `%s'.",
                      pretty_print_cmdline(args))
-        print("Isolate:", " ".join(args))
         # Temporarily allow writing new files.
         prev_permissions = stat.S_IMODE(os.stat(self.path).st_mode)
         os.chmod(self.path, 0777)

--- a/cms/grading/__init__.py
+++ b/cms/grading/__init__.py
@@ -38,7 +38,7 @@ from sqlalchemy.orm import joinedload
 
 from cms import config, \
     LANG_C, LANG_CPP, LANG_CS, LANG_PASCAL, LANG_PYTHON2, LANG_PYTHON3, LANG_PHP, LANG_JAVA, \
-    SCORE_MODE_MAX, LANGUAGE_TO_MAX_PROCCESSORS
+    SCORE_MODE_MAX, LANGUAGE_TO_MAX_PROCCESSORS, PYTHON3_COMPILE_NAME
 from cms.db import Submission
 from cms.grading.Sandbox import Sandbox
 
@@ -262,8 +262,8 @@ def get_compilation_commands(language, source_filenames, executable_filename,
         # mv __pycache__/%s.*.pyc %s
         py_command = ["/usr/bin/python3", "-m", "py_compile",
                       source_filenames[0]]
-        mv_command = ["/bin/mv", "__pycache__/%s.*.pyc" % os.path.splitext(os.path.basename(
-                      source_filenames[0]))[0], executable_filename]
+        mv_command = ["/bin/mv", "__pycache__/%s.%s.pyc" % (os.path.splitext(os.path.basename(
+                      source_filenames[0]))[0], PYTHON3_COMPILE_NAME), executable_filename]
         commands.append(py_command)
         commands.append(mv_command)
     elif language == LANG_PHP:

--- a/cms/grading/__init__.py
+++ b/cms/grading/__init__.py
@@ -257,9 +257,6 @@ def get_compilation_commands(language, source_filenames, executable_filename,
         # The executable name is fixed, and there is no way to specify
         # the name of the pyc, so we need to bundle together two
         # commands (compilation and rename).
-        # In order to use Python 3 change them to:
-        # /usr/bin/python3 -m py_compile %s
-        # mv __pycache__/%s.*.pyc %s
         py_command = ["/usr/bin/python3", "-m", "py_compile",
                       source_filenames[0]]
         mv_command = ["/bin/mv", "__pycache__/%s.%s.pyc" % (os.path.splitext(os.path.basename(

--- a/cms/grading/__init__.py
+++ b/cms/grading/__init__.py
@@ -370,7 +370,6 @@ def compilation_step(sandbox, commands):
     sandbox.address_space = 512 * 1024
     sandbox.stdout_file = "compiler_stdout.txt"
     sandbox.stderr_file = "compiler_stderr.txt"
-    #sandbox.allow_writing_all()
 
     # Actually run the compilation commands.
     logger.debug("Starting compilation step.")

--- a/cms/grading/__init__.py
+++ b/cms/grading/__init__.py
@@ -37,7 +37,7 @@ from collections import namedtuple
 from sqlalchemy.orm import joinedload
 
 from cms import config, \
-    LANG_C, LANG_CPP, LANG_CS, LANG_PASCAL, LANG_PYTHON, LANG_PHP, LANG_JAVA, \
+    LANG_C, LANG_CPP, LANG_CS, LANG_PASCAL, LANG_PYTHON2, LANG_PYTHON3, LANG_PHP, LANG_JAVA, \
     SCORE_MODE_MAX, LANGUAGE_TO_MAX_PROCCESSORS
 from cms.db import Submission
 from cms.grading.Sandbox import Sandbox
@@ -243,16 +243,26 @@ def get_compilation_commands(language, source_filenames, executable_filename,
         command += ["-XS", "-O2", "-o%s" % executable_filename]
         command += [source_filenames[0]]
         commands.append(command)
-    elif language == LANG_PYTHON:
+    elif language == LANG_PYTHON2:
+        # The executable name is fixed, and there is no way to specify
+        # the name of the pyc, so we need to bundle together two
+        # commands (compilation and rename).
+        py_command = ["/usr/bin/python2", "-m", "py_compile",
+                      source_filenames[0]]
+        mv_command = ["/bin/mv", "%s.py2c" % os.path.splitext(os.path.basename(
+                      source_filenames[0]))[0], executable_filename]
+        commands.append(py_command)
+        commands.append(mv_command)
+    elif language == LANG_PYTHON3:
         # The executable name is fixed, and there is no way to specify
         # the name of the pyc, so we need to bundle together two
         # commands (compilation and rename).
         # In order to use Python 3 change them to:
         # /usr/bin/python3 -m py_compile %s
         # mv __pycache__/%s.*.pyc %s
-        py_command = ["/usr/bin/python2", "-m", "py_compile",
+        py_command = ["/usr/bin/python3", "-m", "py_compile",
                       source_filenames[0]]
-        mv_command = ["/bin/mv", "%s.pyc" % os.path.splitext(os.path.basename(
+        mv_command = ["/bin/mv", "__pycache__/%s.*.pyc" % os.path.splitext(os.path.basename(
                       source_filenames[0]))[0], executable_filename]
         commands.append(py_command)
         commands.append(mv_command)
@@ -286,10 +296,11 @@ def get_evaluation_commands(language, executable_filename):
     if language in (LANG_C, LANG_CPP, LANG_PASCAL, LANG_JAVA):
         command = [os.path.join(".", executable_filename)]
         commands.append(command)
-    elif language == LANG_PYTHON:
-        # In order to use Python 3 change it to:
-        # /usr/bin/python3 %s
+    elif language == LANG_PYTHON2:
         command = ["/usr/bin/python2", executable_filename]
+        commands.append(command)
+    elif language == LANG_PYTHON3:
+        command = ["/usr/bin/python3", executable_filename]
         commands.append(command)
     elif language == LANG_CS:
     	command = ["/usr/bin/mono", executable_filename]
@@ -359,6 +370,7 @@ def compilation_step(sandbox, commands):
     sandbox.address_space = 512 * 1024
     sandbox.stdout_file = "compiler_stdout.txt"
     sandbox.stderr_file = "compiler_stderr.txt"
+    #sandbox.allow_writing_all()
 
     # Actually run the compilation commands.
     logger.debug("Starting compilation step.")


### PR DESCRIPTION
Added python 2/3 support as .py2 and .py3 extensions, front end will deal with converting from .py depending on user input.

Had to use full name for renaming .pyc file instead of an asterix as in the original comments due to it failing for unknown reasons when using that.
