### PR TITLE
Hide task type and filenames fields in Overview and Statement tabs

### DIFF
--- a/cms/server/templates/contest/overview.html
+++ b/cms/server/templates/contest/overview.html
@@ -159,8 +159,10 @@
             <th>{{ _("Name") }}</th>
             <th>{{ _("Time limit") }}</th>
             <th>{{ _("Memory limit") }}</th>
+        {% if contest.interface_type != "aio" %}
             <th>{{ _("Type") }}</th>
             <th>{{ _("Files") }}</th>
+        {% end %}
 {% if tokens_contest != 0 and tokens_tasks != 0 %}
             <th>{{ _("Tokens") }}</th>
 {% end %}
@@ -190,8 +192,10 @@
         {{ _("N/A") }}
     {% end %}
             </td>
+        {% if contest.interface_type != "aio" %}
             <td>{{ get_task_type(dataset=t_iter.active_dataset).name }}</td>
             <td>{{ " ".join(a.filename.replace("%l", extensions) for a in t_iter.submission_format) }}</td>
+        {% end %}
     {% if tokens_contest != 0 and tokens_tasks != 0 %}
             <td>
         {% if t_iter.token_mode in ("finite", "infinite") %}

--- a/cms/server/templates/contest/task_description.html
+++ b/cms/server/templates/contest/task_description.html
@@ -94,10 +94,13 @@
         <col style="width: 60%"/>
     </colgroup>
     <tbody>
+    {% set task_type = get_task_type(dataset=task.active_dataset) %}
+    {% if contest.interface_type != "aio" %}
         <tr>
             <th>{{ _("Type") }}</th>
-            <td colspan="2">{% set task_type = get_task_type(dataset=task.active_dataset) %}{{ task_type.name }}</td>
+            <td colspan="2">{{ task_type.name }}</td>
         </tr>
+    {% end %}
 {% if task.active_dataset.time_limit is not None %}
         <tr>
             <th>{{ _("Time limit") }}</th>


### PR DESCRIPTION
Since all AIO tasks are of type Batch and because of this, students only submit a single file with whatever filename they like, these fields are both meaningless and have the potential to confuse (e.g. the py2|py3 file extension listed).
