### PR TITLE
Add interface type [eg AIO] for custom interfaces

### DIFF
--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -79,7 +79,7 @@ __all__ = [
 
 # Instantiate or import these objects.
 
-version = 14
+version = 15
 
 
 engine = create_engine(config.database, echo=config.database_debug,

--- a/cms/db/contest.py
+++ b/cms/db/contest.py
@@ -73,6 +73,13 @@ class Contest(Base):
         nullable=False,
         default=[])
 
+    # The custom interface (if any) to use for contestants. "default"
+    # indicates the standard CMS interface.
+    interface_type = Column(
+        Enum("default", "aio", name="interface_type"),
+        nullable=False,
+        default="default")
+
     # The list of languages shorthand allowed in the contest,
     # e.g. cpp. The codes must be the same as those in cms.LANGUAGES.
     languages = Column(

--- a/cms/server/AdminWebServer.py
+++ b/cms/server/AdminWebServer.py
@@ -595,6 +595,7 @@ class AddContestHandler(BaseHandler):
             else:
                 attrs["allowed_localizations"] = []
 
+            self.get_string(attrs, "interface_type")
             attrs["languages"] = self.get_arguments("languages", [])
 
             self.get_string(attrs, "token_mode")
@@ -662,6 +663,7 @@ class ContestHandler(BaseHandler):
             else:
                 attrs["allowed_localizations"] = []
 
+            self.get_string(attrs, "interface_type")
             attrs["languages"] = self.get_arguments("languages", [])
 
             self.get_string(attrs, "token_mode")

--- a/cms/server/templates/admin/add_contest.html
+++ b/cms/server/templates/admin/add_contest.html
@@ -25,6 +25,15 @@
       <td><input type="text" name="allowed_localizations" value=""/></td>
     </tr>
     <tr>
+      <td>Interface type (custom interface)</td>
+      <td>
+        <select name="interface_type">
+          <option value="default">Default</option>
+          <option value="aio">AIO</option>
+        </select>
+      </td>
+    </tr>
+    <tr>
       <td>Languages allowed</td>
       <td>
         {% for lang in LANGUAGES %}

--- a/cms/server/templates/admin/contest.html
+++ b/cms/server/templates/admin/contest.html
@@ -29,6 +29,15 @@
       <td><input type="text" name="allowed_localizations" value="{{ ",".join(contest.allowed_localizations) }}"/></td>
     </tr>
     <tr>
+      <td>Interface type (custom interface)</td>
+      <td>
+        <select name="interface_type">
+          <option value="default" {{ "selected" if contest.interface_type == "default" else "" }}>Default</option>
+          <option value="aio" {{ "selected" if contest.interface_type == "aio" else "" }}>AIO</option>
+        </select>
+      </td>
+    </tr>
+    <tr>
       <td>Languages allowed</td>
       <td>
         {% for lang in LANGUAGES %}

--- a/cmscontrib/updaters/update_15.py
+++ b/cmscontrib/updaters/update_15.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""A class to update a dump created by CMS.
+
+Used by ContestImporter and DumpUpdater.
+
+This updater is no-op as the new field (interface type) has a proper
+default value.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+
+class Updater(object):
+
+    def __init__(self, data):
+        assert data["_version"] == 14
+        self.objs = data
+
+    def run(self):
+        return self.objs


### PR DESCRIPTION
Added an `interface_type` field to `Contest` to specify what type of interface should be used in ContestWebServer. Currently two options are available, namely `"default"` (default CMS interface) and `"aio"` (AIO-specific interface settings).

`cmsInitDB` would need to be run on a blank DB before use. Updater is supplied and seems to update dumps from previous DB versions OK (tested on version 14).
