### PR TITLE
Display batch filenames, reorder Overview table columns for consistency

### DIFF
--- a/cms/grading/tasktypes/Batch.py
+++ b/cms/grading/tasktypes/Batch.py
@@ -106,6 +106,24 @@ class Batch(TaskType):
         # TODO add some details if a grader/comparator is used, etc...
         return "Batch"
 
+    @property
+    def input_filename(self):
+        """Returns the name of the input file.
+
+        return (str): the name
+        
+        """
+        return self.parameters[1][0]
+
+    @property
+    def output_filename(self):
+        """Returns the name of the output file.
+
+        return (str): the name
+        
+        """
+        return self.parameters[1][1]
+
     def get_compilation_commands(self, submission_format):
         """See TaskType.get_compilation_commands."""
         res = dict()

--- a/cms/server/templates/contest/overview.html
+++ b/cms/server/templates/contest/overview.html
@@ -157,12 +157,16 @@
         <tr>
             <th>{{ _("Task") }}</th>
             <th>{{ _("Name") }}</th>
+{% if contest.interface_type != "aio" %}
+            <th>{{ _("Type") }}</th>
+{% end %}
             <th>{{ _("Time limit") }}</th>
             <th>{{ _("Memory limit") }}</th>
-        {% if contest.interface_type != "aio" %}
-            <th>{{ _("Type") }}</th>
-            <th>{{ _("Files") }}</th>
-        {% end %}
+            <th>{{ _("Input File") }}</th>
+            <th>{{ _("Output File") }}</th>
+{% if contest.interface_type != "aio" %}
+            <th>{{ _("Submission files") }}</th>
+{% end %}
 {% if tokens_contest != 0 and tokens_tasks != 0 %}
             <th>{{ _("Tokens") }}</th>
 {% end %}
@@ -174,6 +178,10 @@
         <tr>
             <th>{{ t_iter.name }}</th>
             <td>{{ t_iter.title }}</td>
+    {% set task_type = get_task_type(dataset=t_iter.active_dataset) %}
+    {% if contest.interface_type != "aio" %}
+            <td>{{ task_type.name }}</td>
+    {% end %}
             <td>
     {% if t_iter.active_dataset.time_limit is not None %}
         {% if t_iter.active_dataset.time_limit == 1.0 %}
@@ -192,10 +200,23 @@
         {{ _("N/A") }}
     {% end %}
             </td>
-        {% if contest.interface_type != "aio" %}
-            <td>{{ get_task_type(dataset=t_iter.active_dataset).name }}</td>
+            <td>
+    {% if task_type.name == "Batch" %}
+        {{ task_type.input_filename if task_type.input_filename != "" else "standard input" }}
+    {% else %}
+        {{ _("N/A") }}
+    {% end %}
+            </td>
+            <td>
+    {% if task_type.name == "Batch" %}
+        {{ task_type.output_filename if task_type.output_filename != "" else "standard output" }}
+    {% else %}
+        {{ _("N/A") }}
+    {% end %}
+            </td>
+    {% if contest.interface_type != "aio" %}
             <td>{{ " ".join(a.filename.replace("%l", extensions) for a in t_iter.submission_format) }}</td>
-        {% end %}
+    {% end %}
     {% if tokens_contest != 0 and tokens_tasks != 0 %}
             <td>
         {% if t_iter.token_mode in ("finite", "infinite") %}

--- a/cms/server/templates/contest/overview.html
+++ b/cms/server/templates/contest/overview.html
@@ -162,8 +162,8 @@
 {% end %}
             <th>{{ _("Time limit") }}</th>
             <th>{{ _("Memory limit") }}</th>
-            <th>{{ _("Input File") }}</th>
-            <th>{{ _("Output File") }}</th>
+            <th>{{ _("Input file") }}</th>
+            <th>{{ _("Output file") }}</th>
 {% if contest.interface_type != "aio" %}
             <th>{{ _("Submission files") }}</th>
 {% end %}

--- a/cms/server/templates/contest/task_description.html
+++ b/cms/server/templates/contest/task_description.html
@@ -119,6 +119,16 @@
             <td colspan="2">{{ _("%(mb)d MiB") % {"mb": task.active_dataset.memory_limit} }}</td>
         </tr>
 {% end %}
+{% if task_type.name == "Batch" %}
+        <tr>
+            <th>{{ _("Input File") }}</th>
+            <td colspan="2">{{ task_type.input_filename if task_type.input_filename != "" else "standard input" }}</td>
+        </tr>
+        <tr>
+            <th>{{ _("Output File") }}</th>
+            <td colspan="2">{{ task_type.output_filename if task_type.output_filename != "" else "standard output" }}</td>
+        </tr>
+{% end %}
 {% set compilation_commands = task_type.get_compilation_commands([x.filename for x in task.submission_format]) %}
 {% if compilation_commands is not None %}
 {% set compilation_commands = {lang: compilation_commands[lang] for lang in contest.languages} %}

--- a/cms/server/templates/contest/task_description.html
+++ b/cms/server/templates/contest/task_description.html
@@ -121,11 +121,11 @@
 {% end %}
 {% if task_type.name == "Batch" %}
         <tr>
-            <th>{{ _("Input File") }}</th>
+            <th>{{ _("Input file") }}</th>
             <td colspan="2">{{ task_type.input_filename if task_type.input_filename != "" else "standard input" }}</td>
         </tr>
         <tr>
-            <th>{{ _("Output File") }}</th>
+            <th>{{ _("Output file") }}</th>
             <td colspan="2">{{ task_type.output_filename if task_type.output_filename != "" else "standard output" }}</td>
         </tr>
 {% end %}


### PR DESCRIPTION
This is something that seems useful beyond just the AIO, and as such doesn't require the AIO interface type to enable.

Intentionally added properties to Batch to deal with internal representation (ie TaskType parameters) and delegated display to the template (eg `"standard input"` instead of `""`).
