### PR TITLE
Add Language column to submissions table

### DIFF
--- a/cms/server/static/cws_style.css
+++ b/cms/server/static/cws_style.css
@@ -462,6 +462,10 @@ td.token_rules p:last-child {
     width: 20%;
 }
 
+#submission_list colgroup col.language {
+    width: 1%;
+}
+
 #submission_list colgroup col.files {
     width: 10%;
 }
@@ -483,6 +487,10 @@ td.token_rules p:last-child {
 #submission_list tbody tr td.status .details {
     float: right;
     cursor: pointer;
+}
+
+#submission_list tbody tr td.language {
+    white-space: nowrap;
 }
 
 #submission_list tbody tr td.files,

--- a/cms/server/templates/contest/submission_row.html
+++ b/cms/server/templates/contest/submission_row.html
@@ -84,6 +84,9 @@
         {% end %}
     {% end %}
 {% end %}
+    <td class="language">
+        {{ submission_lang_list.get(s.language, "") }}
+    </td>
     <td class="files">
         {% comment We replace '%l' with the actual language only when it occurs as an extension at the end of the string and only when %}
         {% comment there isn't another file with that name. This allows to securily reverse the replacement and should work great in %}

--- a/cms/server/templates/contest/task_submissions.html
+++ b/cms/server/templates/contest/task_submissions.html
@@ -231,6 +231,7 @@ $(document).ready(function () {
 {% else %}
         <col class="total_score"/>
 {% end %}
+        <col class="language"/>
         <col class="files"/>
 {% if tokens_contest != 0 and tokens_tasks != 0 %}
         <col class="token"/>
@@ -250,6 +251,7 @@ $(document).ready(function () {
 {% else %}
             <th class="total_score">{{ _("Score") }}</th>
 {% end %}
+            <th class="language">{{ _("Language") }}</th>
             <th class="files">{{ _("Files") }}</th>
 {% if tokens_contest != 0 and tokens_tasks != 0 %}
             <th class="token">{{ _("Token") }}</th>


### PR DESCRIPTION
This should exist whenever the drop-down language selector exists to
allow students to double-check that they picked the correct language
for their submission. Displays an empty string if it can't match the
file extension.
