### PR TITLE
Restyle language selector to browser default

### DIFF
--- a/cms/server/static/css/bootstrap.css
+++ b/cms/server/static/css/bootstrap.css
@@ -189,7 +189,7 @@ input[type="radio"],input[type="checkbox"]{margin:3px 0;*margin-top:0;line-heigh
 input[type="submit"],input[type="reset"],input[type="button"],input[type="radio"],input[type="checkbox"]{width:auto;}
 .uneditable-textarea{width:auto;height:auto;}
 select,input[type="file"]{height:28px;*margin-top:4px;line-height:28px;}
-select{width:220px;border:1px solid #bbb;}
+select{width:220px;}
 select[multiple],select[size]{height:auto;}
 select:focus,input[type="file"]:focus,input[type="radio"]:focus,input[type="checkbox"]:focus{outline:thin dotted #333;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px;}
 .radio,.checkbox{min-height:18px;padding-left:18px;}

--- a/cms/server/static/cws_style.css
+++ b/cms/server/static/cws_style.css
@@ -442,6 +442,13 @@ td.token_rules p:last-child {
     line-height: 18px;
 }
 
+#submission_lang {
+    height: auto;
+    padding-left: 2px;
+    padding-top: 0px;
+    padding-bottom: 0px;
+    padding-right: 0px;
+}
 
 /*** Submissions table */
 


### PR DESCRIPTION
Changed bootstrap.css so that it doesn't specify a default border style on
`<select>` elements. On most browsers, specifying any border style whatsoever
will result in it not rendering the dropdown as default, hence, it is
impossible to specify styling elements on individual elements to prevent this
behaviour.

Bootstrap is only used on CWS, and within it, `<select>` is only used in one
other place; namely the i18n language selector box, which overrides this style
anyway. It doesn't seem super-critical and any future `<select>` elements that
desire this border style (`1px solid #BBB`) should manually apply this style.

Tested on Chrome and FF and renders fine on both.
