### PR TITLE
Display output of first compiler command only

### DIFF
--- a/cms/grading/__init__.py
+++ b/cms/grading/__init__.py
@@ -444,20 +444,25 @@ def compilation_step(sandbox, commands):
 
     # Actually run the compilation commands.
     logger.debug("Starting compilation step.")
-    for command in commands:
+
+    stdout = ""
+    stderr = ""
+    for index, command in enumerate(commands):
         box_success = sandbox.execute_without_std(command, wait=True)
         if not box_success:
             logger.error("Compilation aborted because of "
                          "sandbox error in `%s'.", sandbox.path)
             return False, None, None, None
+        else:
+            if index == 0:
+                stdout = sandbox.get_file_to_string("compiler_stdout.txt")
+                stdout = unicode(stdout, 'utf-8', errors='replace')
+                stderr = sandbox.get_file_to_string("compiler_stderr.txt")
+                stderr = unicode(stderr, 'utf-8', errors='replace')
 
     # Detect the outcome of the compilation.
     exit_status = sandbox.get_exit_status()
     exit_code = sandbox.get_exit_code()
-    stdout = sandbox.get_file_to_string("compiler_stdout.txt")
-    stdout = unicode(stdout, 'utf-8', errors='replace')
-    stderr = sandbox.get_file_to_string("compiler_stderr.txt")
-    stderr = unicode(stderr, 'utf-8', errors='replace')
 
     # And retrieve some interesting data.
     plus = {


### PR DESCRIPTION
Currently, CMS displays the stdout/stderr of the last compilation command that
is run. We are electing to instead display the stdout/stderr of the first
such command, as the first command is usually the most vital.

Currently, only for Python do we use multiple commands of which the second (and
last) is a `/usr/bin/mv` operation. In the case when the Python compilation
fails, the output file will not be produced so the `/usr/bin/mv` will also fail.
As this second failure is likely to confuse inexperienced users, we elect to
only show the output of the first command, and not all of them.
