### PR TITLE
Add IOI scoretype for groupMin

### DIFF
--- a/cms/grading/ScoreType.py
+++ b/cms/grading/ScoreType.py
@@ -443,9 +443,10 @@ class IOIScoreTypeGroup(ScoreTypeGroup):
     {% if "score" in st and "max_score" in st %}
         {% set sub_idx = sub_idx + (st["max_score"] != 0) %}
         {% set sampletask = (st["max_score"] == 0) %}
-        {% if st["score"] >= st["max_score"] %}
+        {% set stscores = [tc["score"] for tc in st["testcases"]] %}
+        {% if (st["score"] >= st["max_score"] and not sampletask) or (sampletask and min(stscores) >= 1.0) %}
 <div class="subtask correct">
-        {% elif st["score"] <= 0.0 %}
+        {% elif (st["score"] <= 0.0 and not sampletask) or (sampletask and min(stscores) <= 0) %}
 <div class="subtask notcorrect">
         {% else %}
 <div class="subtask partiallycorrect">
@@ -564,7 +565,7 @@ class IOIScoreTypeGroup(ScoreTypeGroup):
             for idx in target:
                 sc = evaluations[idx].outcome
                 try:
-                    sc = float(sc) * parameter[0]
+                    sc = float(sc)
                 except:
                     sc = 0.0
 

--- a/cms/grading/ScoreType.py
+++ b/cms/grading/ScoreType.py
@@ -438,7 +438,6 @@ class IOIScoreTypeGroup(ScoreTypeGroup):
 {% from cms.grading import format_status_text %}
 {% from cms.server import format_size %}
 {% set idx = 0 %}
-uwotm8
 {% for st in details %}
     {% if "score" in st and "max_score" in st %}
         {% if st["score"] >= st["max_score"] %}

--- a/cms/grading/ScoreType.py
+++ b/cms/grading/ScoreType.py
@@ -438,8 +438,11 @@ class IOIScoreTypeGroup(ScoreTypeGroup):
 {% from cms.grading import format_status_text %}
 {% from cms.server import format_size %}
 {% set idx = 0 %}
+{% set sub_idx = 0 %}
 {% for st in details %}
     {% if "score" in st and "max_score" in st %}
+        {% set sub_idx = sub_idx + (st["max_score"] != 0) %}
+        {% set sampletask = (st["max_score"] == 0) %}
         {% if st["score"] >= st["max_score"] %}
 <div class="subtask correct">
         {% elif st["score"] <= 0.0 %}
@@ -452,7 +455,11 @@ class IOIScoreTypeGroup(ScoreTypeGroup):
     {% end %}
     <div class="subtask-head">
         <span class="title">
-            {{ _("Subtask %d") % st["idx"] }}
+            {% if sampletask %}
+		Sample Data
+            {% else %}
+		{{ _("Subtask %d") % sub_idx }}
+            {% end %}
         </span>
     {% if "score" in st and "max_score" in st %}
         <span class="score">
@@ -481,7 +488,9 @@ class IOIScoreTypeGroup(ScoreTypeGroup):
         {% set idx = idx + 1 %}
         {% set tcs = tcs + [(tc["score"], idx, tc)] %}
     {% end %}
-    {% set tcs = sorted(tcs)[:1] %}
+    {% if st["max_score"] != 0 %}
+        {% set tcs = sorted(tcs)[:1] %}
+    {% end %}
     {% for sc, idxx, tc in tcs %}
         {% if "outcome" in tc and "text" in tc %}
             {% if tc["outcome"] == "Correct" %}

--- a/cms/grading/ScoreType.py
+++ b/cms/grading/ScoreType.py
@@ -493,8 +493,7 @@ uwotm8
                 <tr class="partiallycorrect">
             {% end %}
                     <td class="idx">{{ idxx }}</td>
-                    <td class="outcome">{{ _(tc["outcome"]) }}
-            ({{ '%g' % round(tc["score"], 2) }} / {{ st["max_score"] }})</td>
+                    <td class="outcome">{{ _(tc["outcome"]) }}</td>
                     <td class="details">
                       {{ format_status_text(tc["text"], _) }}
                     </td>

--- a/cms/grading/scoretypes/IOIGroupMin.py
+++ b/cms/grading/scoretypes/IOIGroupMin.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2010-2012 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
+# Copyright © 2010-2012 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from cms.grading.ScoreType import IOIScoreTypeGroup
+
+
+# Dummy function to mark translatable string.
+def N_(message):
+    return message
+
+
+class IOIGroupMin(IOIScoreTypeGroup):
+    """The score of a submission is the sum of the product of the
+    minimum of the ranges with the multiplier of that range.
+
+    Parameters are [[m, t], ... ] (see ScoreTypeGroup).
+
+    """
+
+    def get_public_outcome(self, outcome, unused_parameter):
+        """See ScoreTypeGroup."""
+        if outcome <= 0.0:
+            return N_("Not correct")
+        elif outcome >= 1.0:
+            return N_("Correct")
+        else:
+            return N_("Partially correct")
+
+    def reduce(self, outcomes, unused_parameter):
+        """See ScoreTypeGroup."""
+        return min(outcomes)


### PR DESCRIPTION
Code was copypasted from `ScoreTypeGroup` for `TEMPLATE` and `compute_score`. Only changes to template are contained within lines 480-500 of `ScoreType.py`, and altered `compute_score` to add the score to the parameter passed into the template.

`IOIGroupMin.py` is an exact copy of `GroupMin.py` with a name change.